### PR TITLE
enable configuration from external library

### DIFF
--- a/src/main/org/deidentifier/arx/ARXConfiguration.java
+++ b/src/main/org/deidentifier/arx/ARXConfiguration.java
@@ -458,7 +458,7 @@ public class ARXConfiguration implements Serializable, Cloneable {
      * Initializes the configuration
      * @param manager
      */
-    protected void initialize(DataManager manager) {
+    public void initialize(DataManager manager) {
 
         // Check
         if (criteria.isEmpty()) { throw new RuntimeException("At least one privacy criterion must be specified!"); }


### PR DESCRIPTION
when we include the arx framework and try to setup the configuration we need to access the initialize function externally
