### PR TITLE
Improve entropy-l-diversity criteria class

### DIFF
--- a/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
+++ b/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
@@ -31,9 +31,6 @@ public class EntropyLDiversity extends LDiversity {
     /**  SVUID */
     private static final long   serialVersionUID = -354688551915634000L;
 
-    /** Helper. */
-    private final double        logL;
-
     /**
      * Creates a new instance of the entropy l-diversity criterion as proposed in:
      * Machanavajjhala A, Kifer D, Gehrke J.
@@ -45,7 +42,6 @@ public class EntropyLDiversity extends LDiversity {
      */
     public EntropyLDiversity(String attribute, double l){
         super(attribute, l, false, true);
-        logL = Math.log(l);
     }
 
     @Override
@@ -57,7 +53,9 @@ public class EntropyLDiversity extends LDiversity {
         if (d.size() < minSize) { return false; }
 
         // Sum of the frequencies in distribution (=number of elements)
-        int total = entry.count;
+        final int total = entry.count;
+        // Sum must stay smaller than this constant term
+        final double C = total * Math.log(total / l);
         double sum1 = 0d;
 
         final int[] buckets = d.getBuckets();
@@ -65,13 +63,13 @@ public class EntropyLDiversity extends LDiversity {
             if (buckets[i] != -1) { // bucket not empty
                 final double frequency = buckets[i + 1];
                 sum1 += frequency * Math.log(frequency);
+                // If the sum grows over C, we can abort the loop earlier.
+                if (C < sum1) { return false; }
             }
         }
 
-        final double val = Math.log(total) - (sum1 / total);
-
-        // check
-        return val >= logL;
+        // If we reach this point, the loop did not return false.
+        return true;
     }
 
 	@Override

--- a/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
+++ b/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
@@ -57,7 +57,7 @@ public class EntropyLDiversity extends LDiversity {
         if (d.size() < minSize) { return false; }
 
         // Sum of the frequencies in distribution (=number of elements)
-        double total = 0;
+        int total = entry.count;
         double sum1 = 0d;
 
         final int[] buckets = d.getBuckets();
@@ -65,7 +65,6 @@ public class EntropyLDiversity extends LDiversity {
             if (buckets[i] != -1) { // bucket not empty
                 final double frequency = buckets[i + 1];
                 sum1 += frequency * Math.log(frequency);
-                total += frequency;
             }
         }
 

--- a/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
+++ b/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
@@ -33,9 +33,6 @@ public class EntropyLDiversity extends LDiversity {
 
     /** Helper. */
     private final double        logL;
-    
-    /** Helper. */
-    private static final double log2             = Math.log(2);
 
     /**
      * Creates a new instance of the entropy l-diversity criterion as proposed in:
@@ -48,7 +45,7 @@ public class EntropyLDiversity extends LDiversity {
      */
     public EntropyLDiversity(String attribute, double l){
         super(attribute, l, false, true);
-        logL = Math.log(l) / Math.log(2d);
+        logL = Math.log(l);
     }
 
     @Override
@@ -67,12 +64,12 @@ public class EntropyLDiversity extends LDiversity {
         for (int i = 0; i < buckets.length; i += 2) {
             if (buckets[i] != -1) { // bucket not empty
                 final double frequency = buckets[i + 1];
-                sum1 += frequency * log2(frequency);
+                sum1 += frequency * Math.log(frequency);
                 total += frequency;
             }
         }
 
-        final double val = -((sum1 / total) - log2(total));
+        final double val = Math.log(total) - (sum1 / total);
 
         // check
         return val >= logL;
@@ -82,16 +79,6 @@ public class EntropyLDiversity extends LDiversity {
 	public String toString() {
 		return "entropy-"+l+"-diversity for attribute '"+attribute+"'";
 	}
-    
-	/**
-     * Computes log 2.
-     *
-     * @param num
-     * @return
-     */
-    private final double log2(final double num) {
-        return Math.log(num) / log2;
-    }
 
     @Override
     public EntropyLDiversity clone() {


### PR DESCRIPTION
The entropy-l-diversity checking method `isAnonymous()` is improved in several ways:

1. Omit log-base 2 normalization, since the underlying inequality is linear in the logarithm and can thus be written in any base.
2. Use `entry.count` instead of creating the `total` sum during the for loop.
3. The underlying inequality can be written so that the sum must not be larger than the introduced constant `C`. This allows to abort the for loop earlier, as soon as the sum grows over `C`.