### PR TITLE
Grassberger l diversity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /junit_test_hierarchy_age.csv
 /jars
 /test.ahs
+/build

--- a/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
+++ b/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
@@ -17,6 +17,9 @@
 
 package org.deidentifier.arx.criteria;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
 import org.deidentifier.arx.framework.check.distribution.Distribution;
 import org.deidentifier.arx.framework.check.groupify.HashGroupifyEntry;
 
@@ -32,7 +35,7 @@ public class EntropyLDiversity extends LDiversity {
     private static final long   serialVersionUID = -354688551915634000L;
     
     /** Entropy Estimator to use */
-    protected final EntropyEstimator estimator;
+    protected EntropyEstimator estimator;
 
     /**
      * Creates a new instance of the entropy l-diversity criterion as proposed in:
@@ -247,5 +250,25 @@ public class EntropyLDiversity extends LDiversity {
             return Math.log(n) +
                     m *(s1 - m *(s2 - m*s3));
         }
+    }
+    
+    /**
+     * Custom deserialization
+     * 
+     * If we deserialize an older object where the entropy estimator
+     * could not be chosen, set the estimator to the default: Shannon.
+     * 
+     * @param ois
+     * @throws ClassNotFoundException
+     * @throws IOException
+     */
+    private void readObject(ObjectInputStream ois)
+    		throws ClassNotFoundException, IOException {
+    	// default deserialization
+    	ois.defaultReadObject();
+    	// Set default estimator if deserializing an older object
+    	if(this.estimator == null) {
+    		this.estimator = EntropyEstimator.SHANNON;
+    	}
     }
 }

--- a/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
+++ b/src/main/org/deidentifier/arx/criteria/EntropyLDiversity.java
@@ -30,6 +30,9 @@ public class EntropyLDiversity extends LDiversity {
 
     /**  SVUID */
     private static final long   serialVersionUID = -354688551915634000L;
+    
+    /** Entropy Estimator to use */
+    protected final EntropyEstimator estimator;
 
     /**
      * Creates a new instance of the entropy l-diversity criterion as proposed in:
@@ -42,11 +45,42 @@ public class EntropyLDiversity extends LDiversity {
      */
     public EntropyLDiversity(String attribute, double l){
         super(attribute, l, false, true);
+        this.estimator = EntropyEstimator.SHANNON;
     }
     
-    @Override
+    /**
+     * Creates a new instance of the entropy-l-diversity criterion,
+     * specifying the entropy estimator to use.
+     * Two estimators are available:
+     * - SHANNON for the usual naive Shannon estimator.
+     *   This amounts to the original entropy-l-diversity definition by Machanavajjhala.
+     * - GRASSBERGER for the corrected Grassberger estimator as proposed in:
+     *   P Grassberger. Entropy Estimates from Insufficient Samplings.
+     *   https://arxiv.org/abs/physics/0307138v2
+     *   This estimator generally accepts more sets as being entropy-l-diverse than
+     *   the naive Shannon estimator, thus increases data utility of the global optimal
+     *   anonymization. It also guarantees a more consistent meaning of the security
+     *   parameter l between different data sets. For details, consult:
+     *   S Stammler, S Katzenbeisser, K Hamacher.
+     *   Correcting Finite Sampling Issues in Entropy l-diversity.
+     *   Privacy in Statistical Databases 2016. LNCS Vol. 9867 pp 135-146
+     * @param attribute The sensitive attribute
+     * @param l Security parameter
+     * @param estimator Entropy estimator (SHANNON or GRASSBERGER)
+     */
+    public EntropyLDiversity(String attribute, double l,
+    		EntropyEstimator estimator) {
+    	super(attribute, l, false, true);
+        this.estimator = estimator;
+	}
+
+    public EntropyEstimator getEstimator() {
+		return estimator;
+	}
+
+	@Override
     public EntropyLDiversity clone() {
-        return new EntropyLDiversity(this.getAttribute(), this.getL());
+        return new EntropyLDiversity(this.getAttribute(), this.getL(), this.getEstimator());
     }
 
     @Override
@@ -60,14 +94,14 @@ public class EntropyLDiversity extends LDiversity {
         // Sum of the frequencies in distribution (=number of elements)
         final int total = entry.count;
         // Sum must stay smaller than this constant term
-        final double C = total * Math.log(total / l);
+        final double C = total * (estimator.psi(total) - Math.log(l));
         double sum1 = 0d;
 
         final int[] buckets = d.getBuckets();
         for (int i = 0; i < buckets.length; i += 2) {
             if (buckets[i] != -1) { // bucket not empty
-                final double frequency = buckets[i + 1];
-                sum1 += frequency * Math.log(frequency);
+                final int frequency = buckets[i + 1];
+                sum1 += frequency * estimator.psi(frequency);
                 // If the sum grows over C, we can abort the loop earlier.
                 if (C < sum1) { return false; }
             }
@@ -84,6 +118,134 @@ public class EntropyLDiversity extends LDiversity {
 
     @Override
 	public String toString() {
-		return "entropy-"+l+"-diversity for attribute '"+attribute+"'";
+		return estimator.toString().toLowerCase()+"-entropy-"+
+					l+"-diversity for attribute '"+attribute+"'";
 	}
+    
+    /**
+     * Enumerator of entropy estimators for the entropy-l-diversity criteria
+     * This enumerator actually holds the logarithm substitute \psi for
+     * entropy estimation via the formula
+     *   $H = \psi(N) - 1/N \sum n \psi (n)$
+     *
+     * @author Sebastian Stammler
+     *
+     */
+    public enum EntropyEstimator {
+    	SHANNON(n -> Math.log(n)),
+    	GRASSBERGER(n -> G(n));
+    	
+    	/** In Java, we need to use an inner functional interface
+    	 * to have an enumerator of functions... doh
+    	 */
+    	private interface IPsi {
+    		public double f(int n);
+    	}
+    	
+    	private final IPsi psi;
+    	
+    	private EntropyEstimator(IPsi psi) {
+    		this.psi = psi;
+    	}
+    	
+    	/**
+    	 * The logarithm substitute of the current estimator
+    	 * 
+    	 * The difference in estimating the entropy by the naive Shannon or Grassberger
+    	 * estimator is actually using log or G for \psi in the entropy formula
+    	 *    $H = \psi(N) - 1/N \sum n \psi(n)$
+    	 * where N is the size of the set and the sum goes over all values of the
+    	 * sensitive attribute, n is the count of the current sensitive attribute
+    	 *  
+    	 * @param n
+    	 * @return The logarithm substitute of the estimator
+    	 */
+    	public double psi(int n) {
+    		return psi.f(n);
+    	}
+    	
+    	/**
+         * Holds precomputed values of G_n for 1 <= n <= 100
+         * It is G_1 = G_PRECOMPUTED[0].
+         * For n>1, we have G_{2n+1} := G_{2n}, so we only store the values for even index:
+         * G_{2n} = G_PRECOMPUTED[n]
+         */
+        final private static double [] G_PRECOMPUTED = {
+                -1.2703628454614782, // G_1
+                0.7296371545385218, // G_2
+                1.3963038212051886, // G_4
+                1.7963038212051885, // G_6
+                2.0820181069194743, // G_8
+                2.3042403291416966, // G_10
+                2.4860585109598783, // G_12
+                2.639904664806032, // G_14
+                2.7732379981393653, // G_16
+                2.8908850569628948, // G_18
+                2.9961482148576315, // G_20
+                3.091386310095727, // G_22
+                3.178342831834857, // G_24
+                3.2583428318348573, // G_26
+                3.3324169059089312, // G_28
+                3.4013824231503107, // G_30
+                3.4658985521825687, // G_32
+                3.5265046127886293, // G_34
+                3.5836474699314866, // G_36
+                3.6377015239855406, // G_38
+                3.6889835752675917, // G_40
+                3.7377640630724698, // G_42
+                3.7842756909794466, // G_44
+                3.8287201354238913, // G_46
+                3.871273326913253, // G_48
+                3.912089653443865, // G_50
+                3.951305339718375, // G_52
+                3.9890411887749786, // G_54
+                4.025404825138615, // G_56
+                4.060492544436861, // G_58
+                4.094390849521607, // G_60
+                4.127177734767508, // G_62
+                4.1589237665135395, // G_64
+                4.18969299728277, // G_66
+                4.219543743551427, // G_68
+                4.248529250797804, // G_70
+                4.276698264882311, // G_72
+                4.304095525156284, // G_74
+                4.33076219182295, // G_76
+                4.356736217796977, // G_78
+                4.382052673493179, // G_80
+                4.40674403151787, // G_82
+                4.430840417060039, // G_84
+                4.454369828824745, // G_86
+                4.477358334571871, // G_88
+                4.49983024468423, // G_90
+                4.521808266662253, // G_92
+                4.543313643006339, // G_94
+                4.564366274585286, // G_96
+                4.5849848312863175, // G_98
+                4.605186851488337, // G_100
+        };
+
+        final private static double s1 = 1d/24;
+        final private static double s2 = 7d/960;
+        final private static double s3 = 31d/8064;
+        /**
+         * Calculates the Grassberger entropy correction term G_n
+         *
+         * $$G_{2n+1} := G_{2n} = -\gamma -\log2 +\sum_{k=1}^n 2/(2k-1)$$
+         * The first 100 values are precomputed. After that, an expansion of the Digamma function at infinity is used.
+         *
+         * @param n > 0 (not checked!)
+         * @return G_n
+         */
+        private static double G(int n) {
+            if (n <= 100) {
+                return G_PRECOMPUTED[(n-n%2)/2];
+            }
+
+            n -= n%2; // Make n even
+            final double m = 1d / ((n/2)*(n/2));
+
+            return Math.log(n) +
+                    m *(s1 - m *(s2 - m*s3));
+        }
+    }
 }


### PR DESCRIPTION
Add possibility to choose the entropy estimator (Shannon or [Grassberger](https://arxiv.org/abs/physics/0307138v2)) during the instantiation of an `EntropyLDiversity` criterion.
I realized this by adding an enumerator `EntropyEstimator` to the `EntropyLDiversity` class, which basically selects the logarithm subsitute in the entropy estimation formula.

The default is, as was the only option before, the naive Shannon estimator. This also reflects the original definition of entropy-l-diversity. To keep the class compatible with old serializations, I added a custom deserializer, which first executes the default deserialization and then sets the estimator to Shannon if it is `null` after deserialization. This custom deserialization has not been tested yet.

The newly added option is to use the Grassberger estimator, see [this paper](https://link.springer.com/chapter/10.1007/978-3-319-45381-1_11) for a comparison to the default Shannon estimator.

The unit test `TestAnonymizationLDiversity` completes successfully. **It remains to add test cases for the Grassberger entropy estimator.**