### PR TITLE
Fix calculation of row height for data tables

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableColumnHeaderConfiguration.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableColumnHeaderConfiguration.java
@@ -73,7 +73,7 @@ public class DataTableColumnHeaderConfiguration extends DefaultColumnHeaderStyle
      */
     private void addNormalModeStyling(final IConfigRegistry configRegistry) {
 
-        final TextPainter txtPainter = new TextPainter(false, false);
+        final TextPainter txtPainter = new TextPainter(false, false, true, true);
         final ICellPainter bgImagePainter = new BackgroundImagePainter(txtPainter,
                                                                        IMAGE_COL_BACK,
                                                                        GUIHelper.getColor(192, 192, 192));

--- a/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableRowHeaderConfiguration.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableRowHeaderConfiguration.java
@@ -50,7 +50,7 @@ public class DataTableRowHeaderConfiguration extends DefaultRowHeaderStyleConfig
         this.font = context.getFont();
         IMAGE_ROW_BACK   = context.getController().getResources().getManagedImage("row_header_bg.png");         //$NON-NLS-1$
         IMAGE_ROW_SELECT = context.getController().getResources().getManagedImage("selected_row_header_bg.png"); //$NON-NLS-1$
-        final TextPainter txtPainter = new TextPainter(false, false);
+        final TextPainter txtPainter = new TextPainter(false, false, true, true);
         final ICellPainter bgImagePainter = new BackgroundImagePainter(txtPainter, IMAGE_ROW_BACK, null);
         cellPainter = bgImagePainter;
     }

--- a/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableRowHeaderConfiguration.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/common/datatable/DataTableRowHeaderConfiguration.java
@@ -50,7 +50,7 @@ public class DataTableRowHeaderConfiguration extends DefaultRowHeaderStyleConfig
         this.font = context.getFont();
         IMAGE_ROW_BACK   = context.getController().getResources().getManagedImage("row_header_bg.png");         //$NON-NLS-1$
         IMAGE_ROW_SELECT = context.getController().getResources().getManagedImage("selected_row_header_bg.png"); //$NON-NLS-1$
-        final TextPainter txtPainter = new TextPainter(false, false, true, true);
+        final TextPainter txtPainter = new TextPainter(false, false);
         final ICellPainter bgImagePainter = new BackgroundImagePainter(txtPainter, IMAGE_ROW_BACK, null);
         cellPainter = bgImagePainter;
     }

--- a/src/gui/org/deidentifier/arx/gui/view/impl/common/table/StyleConfigurationHeader.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/common/table/StyleConfigurationHeader.java
@@ -68,7 +68,7 @@ public class StyleConfigurationHeader extends CTStyleConfiguration {
     private final BorderStyle             borderStyle     = null;
     
     /**  TODO */
-    private final ICellPainter            cellPainter     = new BeveledBorderDecorator(new TextPainter());
+    private final ICellPainter            cellPainter     = new BeveledBorderDecorator(new TextPainter(false, false, true, true));
     
     /**  TODO */
     private final Boolean                 renderGridLines = Boolean.FALSE;


### PR DESCRIPTION
This is an attempt to fix issues with the row height for data tables (#80). The bug itself was reported [upstream][1]. However, there seems to be no clean solution. I've tried to fix it as was suggested [here][2], but it doesn't appear to work for me, so this should **not**  be merged. Its just a heads-up that upstream is looking into it. Also I'm not entirely sure if I made the adjustment at the right location, so if you could have a look at it, it would be very much appreciated ;).

[1]: https://bugs.eclipse.org/bugs/show_bug.cgi?id=511784
[2]: https://bugs.eclipse.org/bugs/show_bug.cgi?id=511784#c8