### PR TITLE
Update attribute icons when output has changed.

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewClassificationAttributes.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewClassificationAttributes.java
@@ -154,7 +154,7 @@ public class ViewClassificationAttributes implements IView, ViewStatisticsBasic 
         if (event.part == ModelPart.MODEL) {
            this.model = (Model) event.data;
            update();
-        } else if (event.part == ModelPart.INPUT || event.part == ModelPart.SELECTED_FEATURES_OR_CLASSES || event.part == ModelPart.ATTRIBUTE_TYPE) {
+        } else if (event.part == ModelPart.INPUT || event.part == ModelPart.SELECTED_FEATURES_OR_CLASSES || event.part == ModelPart.ATTRIBUTE_TYPE || event.part == ModelPart.OUTPUT) {
            update();
         }
     }


### PR DESCRIPTION
In the view "Classification accuracy" the attribute image is determined based on either the inputDefinition or the outputDefinition (if exists). In the latter case, the images might need to be updated after the output has changed.