### PR TITLE
Apply an existing ordering to the attribute values when the order selection dialog for an attribute is opened.

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/menu/DialogOrderSelection.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/menu/DialogOrderSelection.java
@@ -462,7 +462,16 @@ public class DialogOrderSelection extends TitleAreaDialog implements IDialog {
                 }
             }
         });
-        sort(this.type);
+        
+        // in case of ARXOrderedString and ARXString perform no initial sort, as there may be an existing ordering present
+        if (DataType.isARXOrderedString(this.type) || DataType.isARXString(this.type)) {
+            list.removeAll();
+            for (final String s : this.elements) {
+                list.add(s);
+            }
+        } else {
+            sort(this.type);
+        }
         return parent;
     }
     

--- a/src/main/org/deidentifier/arx/DataType.java
+++ b/src/main/org/deidentifier/arx/DataType.java
@@ -1732,6 +1732,26 @@ public abstract class DataType<T> implements Serializable, Comparator<T> {
         return result;
     }
     
+    /**
+     * Checks if type is an instance of <code>ARXOrderedString</code>.
+     * 
+     * @param type data type
+     * @return true if type is an instance of <code>ARXOrderedString</code>, otherwise false
+     */
+    final public static boolean isARXOrderedString(DataType<?> type) {
+        return (type instanceof ARXOrderedString);
+    }
+
+    /**
+     * Checks if type is an instance of <code>ARXString</code>.
+     * 
+     * @param type data type
+     * @return true if type is an instance of <code>ARXString</code>, otherwise false
+     */
+    final public static boolean isARXString(DataType<?> type) {
+        return (type instanceof ARXString);
+    }
+    
     @Override
     public abstract DataType<T> clone();
     


### PR DESCRIPTION
Issue description:
When the an attribute already has a stored order, the existing attribute
value ordering is not displayed when the dialog to specify the attribute
value ordering is reopened. Instead the distinct values are shown in the
occurrence order from the input data.

Fix 1:
It applies the existing attribute value order for the attribute values,
if existing. New attribute values that are not present in the existing
order of the attribute are appended to the end of the attribute value
array.

Fix 2:
In case an existing order is loaded from a file a check is included,
when the dialog is closed, that removes entries that are not present in
the input data set.

Fix 3:
When the "DialogOrderSelection" is canceled via the cancel button or the
close icon, the attribute type remains unchanged.