### PR TITLE
Switch parameters of optimizeFast-call.

### DIFF
--- a/src/main/org/deidentifier/arx/ARXResult.java
+++ b/src/main/org/deidentifier/arx/ARXResult.java
@@ -532,7 +532,7 @@ public class ARXResult {
      * @return The number of optimized records
      */
     public ARXProcessStatistics optimize(DataHandle handle, double gsFactor, ARXListener listener) throws RollbackRequiredException {
-        return optimizeFast(handle, gsFactor, Double.NaN, listener);
+        return optimizeFast(handle, Double.NaN, gsFactor, listener);
     }
 
     /**


### PR DESCRIPTION
Fix wrong order of parameters when calling 'optimizeFast' (l. 535)