### PR TITLE
Bugfixes for 3.7.0

### DIFF
--- a/src/main/org/deidentifier/arx/aggregates/StatisticsClassification.java
+++ b/src/main/org/deidentifier/arx/aggregates/StatisticsClassification.java
@@ -375,8 +375,8 @@ public class StatisticsClassification {
                             inputZeroR.train(inputHandle, outputHandle, index);
                             if (outputClassifier != null && !outputHandle.isOutlier(index)) {
                                 outputClassifier.train(outputHandle, outputHandle, index);
+                                trained = true;
                             }
-                            trained = true;
                             this.progress.value = (int)((++done) * total);
                         }
                     }
@@ -385,7 +385,7 @@ public class StatisticsClassification {
                 // Close
                 inputClassifier.close();
                 inputZeroR.close();
-                if (outputClassifier != null) {
+                if (outputClassifier != null && trained) {
                     outputClassifier.close();
                 }
                 
@@ -395,46 +395,43 @@ public class StatisticsClassification {
                     // Check
                     checkInterrupt();
                     
-                    // If trained
-                    if (trained) {
+                    // Classify
+                    ClassificationResult resultInput = inputClassifier.classify(inputHandle, index);
+                    ClassificationResult resultInputZR = inputZeroR.classify(inputHandle, index);
+                    ClassificationResult resultOutput = outputClassifier == null || !trained ? null : outputClassifier.classify(outputHandle, index);
+                    classifications++;
                         
-                        // Classify
-                        ClassificationResult resultInput = inputClassifier.classify(inputHandle, index);
-                        ClassificationResult resultInputZR = inputZeroR.classify(inputHandle, index);
-                        ClassificationResult resultOutput = outputClassifier == null ? null : outputClassifier.classify(outputHandle, index);
-                        classifications++;
+                    // Correct result
+                    String actualValue = outputHandle.getValue(index, specification.classIndex, true);
                         
-                        // Correct result
-                        String actualValue = outputHandle.getValue(index, specification.classIndex, true);
-                        
-                        // Maintain data about ZeroR
-                        this.zeroRAverageError += resultInputZR.error(actualValue);
-                        this.zeroRAccuracy += resultInputZR.correct(actualValue) ? 1d : 0d;
-                        double[] confidences = resultInputZR.confidences();
-                        zerorConfidences[confidencesIndex] = index;
-                        System.arraycopy(confidences, 0, zerorConfidences, confidencesIndex + 1, confidences.length);
+                    // Maintain data about ZeroR
+                    this.zeroRAverageError += resultInputZR.error(actualValue);
+                    this.zeroRAccuracy += resultInputZR.correct(actualValue) ? 1d : 0d;
+                    double[] confidences = resultInputZR.confidences();
+                    zerorConfidences[confidencesIndex] = index;
+                    System.arraycopy(confidences, 0, zerorConfidences, confidencesIndex + 1, confidences.length);
 
-                        // Maintain data about input-based classifier
-                        boolean correct = resultInput.correct(actualValue);
-                        this.originalAverageError += resultInput.error(actualValue);
-                        this.originalAccuracy += correct ? 1d : 0d;
-                        confidences = resultInput.confidences();
-                        inputConfidences[confidencesIndex] = index;
-                        System.arraycopy(confidences, 0, inputConfidences, confidencesIndex + 1, confidences.length);
+                    // Maintain data about input-based classifier
+                    boolean correct = resultInput.correct(actualValue);
+                    this.originalAverageError += resultInput.error(actualValue);
+                    this.originalAccuracy += correct ? 1d : 0d;
+                    confidences = resultInput.confidences();
+                    inputConfidences[confidencesIndex] = index;
+                    System.arraycopy(confidences, 0, inputConfidences, confidencesIndex + 1, confidences.length);
 
-                        // Maintain data about output-based                     
-                        if (resultOutput != null) {
-                            correct = resultOutput.correct(actualValue);
-                            this.averageError += resultOutput.error(actualValue);
-                            this.accuracy += correct ? 1d : 0d;
-                            confidences = resultOutput.confidences();
-                            outputConfidences[confidencesIndex] = index;
-                            System.arraycopy(confidences, 0, outputConfidences, confidencesIndex + 1, confidences.length);
-                        }
-                        
-                        // Next
-                        confidencesIndex += numClasses + 1;
+                    // Maintain data about output-based                     
+                    if (resultOutput != null) {
+                        correct = resultOutput.correct(actualValue);
+                        this.averageError += resultOutput.error(actualValue);
+                        this.accuracy += correct ? 1d : 0d;
+                        confidences = resultOutput.confidences();
+                        outputConfidences[confidencesIndex] = index;
+                        System.arraycopy(confidences, 0, outputConfidences, confidencesIndex + 1, confidences.length);
                     }
+                        
+                    // Next
+                    confidencesIndex += numClasses + 1;
+                    
                     this.progress.value = (int)((++done) * total);
                 }
             } catch (Exception e) {

--- a/src/main/org/deidentifier/arx/aggregates/classification/MultiClassZeroR.java
+++ b/src/main/org/deidentifier/arx/aggregates/classification/MultiClassZeroR.java
@@ -18,7 +18,6 @@ package org.deidentifier.arx.aggregates.classification;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.deidentifier.arx.DataHandleInternal;
 
@@ -31,7 +30,7 @@ public class MultiClassZeroR implements ClassificationMethod {
     /** Counts */
     private final Map<Integer, Integer>           counts = new HashMap<>();
     /** Result */
-    private Integer                               result = null;
+    private MultiClassZeroRClassificationResult   result = null;
     /** Index */
     private final ClassificationDataSpecification specification;
     
@@ -45,15 +44,13 @@ public class MultiClassZeroR implements ClassificationMethod {
 
     @Override
     public ClassificationResult classify(DataHandleInternal handle, int row) {
-        if (result == null) {
-            result = getIndexWithMostCounts();
-        }
-        return new MultiClassZeroRClassificationResult(result, counts, specification.classMap);
+        return result;
     }
 
     @Override
     public void close() {
-        // Nothing to do
+        result = new MultiClassZeroRClassificationResult(counts, specification.classMap);
+        counts.clear();
     }
 
     @Override
@@ -63,23 +60,5 @@ public class MultiClassZeroR implements ClassificationMethod {
         count = count == null ? 1 : count + 1;
         counts.put(key, count);
         result = null;
-    }
-
-    /**
-     * Returns the index of the most frequent element
-     * @return
-     */
-    private Integer getIndexWithMostCounts() {
-        int max = Integer.MIN_VALUE;
-        Integer result = null;
-        for (Entry<Integer, Integer> entry : counts.entrySet()) {
-            int count = entry.getValue();
-            int index = entry.getKey();
-            if (count > max) {
-                max = count;
-                result = index;
-            }
-        }
-        return result;
     }
 }


### PR DESCRIPTION
- Bugfix: Only evaluate non-suppressed records (as they have been trained)
- Refactor ZeroR result
- Bugfix: Calculate ZeroR confidences correctly