### PR TITLE
Bugfix serialization in ARXFeatureScaling

### DIFF
--- a/src/main/org/deidentifier/arx/ARXFeatureScaling.java
+++ b/src/main/org/deidentifier/arx/ARXFeatureScaling.java
@@ -52,18 +52,12 @@ public class ARXFeatureScaling implements Serializable {
     }
     
     /**
-     * Returns a scaling function
-     * @param attribute
-     * @return
+     * Parse expression string.
+     * @param function
+     * @return the expression 
+     * @throws IllegalArgumentException
      */
-    public Expression getScalingExpression(String attribute) {
-        if (attribute == null) {
-            return null;
-        }
-        String function = this.functions.get(attribute);
-        if (function == null || function.equals("")) {
-            return null;
-        }
+    private Expression getExpression(String function) throws IllegalArgumentException {
         Expression expression = null;
         try {
             expression = new ExpressionBuilder(function).variable("x").build();
@@ -84,6 +78,22 @@ public class ARXFeatureScaling implements Serializable {
      * @param attribute
      * @return
      */
+    public Expression getScalingExpression(String attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        String function = this.functions.get(attribute);
+        if (function == null || function.equals("")) {
+            return null;
+        }
+        return getExpression(function);
+    }
+
+    /**
+     * Returns a scaling function
+     * @param attribute
+     * @return
+     */
     public String getScalingFunction(String attribute) {
         return this.functions.get(attribute);
     }
@@ -97,16 +107,9 @@ public class ARXFeatureScaling implements Serializable {
         if (function == null || function.equals("")) {
             return true;
         }
-        Expression expression = null;
         try {
-            expression = new ExpressionBuilder(function).variable("x").build();
-        } catch (Exception e) {
-            return false;
-        }
-        if (expression == null || !expression.validate(false).isValid()) {
-            return false;
-        }
-        if (expression.getVariableNames().size() != 1 || !expression.getVariableNames().contains("x")) {
+            getExpression(function);
+        } catch (IllegalArgumentException e) {
             return false;
         }
         return true;
@@ -135,18 +138,8 @@ public class ARXFeatureScaling implements Serializable {
             this.functions.remove(attribute);
             return this;
         }
-        Expression expression = null;
-        try {
-            expression = new ExpressionBuilder(function).variable("x").build();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e.getMessage());
-        }
-        if (expression == null || !expression.validate(false).isValid()) {
-            throw new IllegalArgumentException("Invalid function: " + function);
-        }
-        if (expression.getVariableNames().size() != 1 || !expression.getVariableNames().contains("x")) {
-            throw new IllegalArgumentException("Function must have exactly one variable 'x': " + function);
-        }
+        // Check expression string
+        getExpression(function);
         this.functions.put(attribute, function);
         return this;
     }

--- a/src/main/org/deidentifier/arx/ARXFeatureScaling.java
+++ b/src/main/org/deidentifier/arx/ARXFeatureScaling.java
@@ -42,9 +42,6 @@ public class ARXFeatureScaling implements Serializable {
     }
 
     /** Functions for feature scaling */
-    private Map<String, Expression> expressions = new HashMap<>();
-
-    /** Functions for feature scaling */
     private Map<String, String>     functions   = new HashMap<>();
 
     /**
@@ -60,7 +57,26 @@ public class ARXFeatureScaling implements Serializable {
      * @return
      */
     public Expression getScalingExpression(String attribute) {
-        return this.expressions.get(attribute);
+        if (attribute == null) {
+            return null;
+        }
+        String function = this.functions.get(attribute);
+        if (function == null || function.equals("")) {
+            return null;
+        }
+        Expression expression = null;
+        try {
+            expression = new ExpressionBuilder(function).variable("x").build();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        if (expression == null || !expression.validate(false).isValid()) {
+            throw new IllegalArgumentException("Invalid function: " + function);
+        }
+        if (expression.getVariableNames().size() != 1 || !expression.getVariableNames().contains("x")) {
+            throw new IllegalArgumentException("Function must have exactly one variable 'x': " + function);
+        }
+        return expression;
     }
 
     /**
@@ -116,7 +132,6 @@ public class ARXFeatureScaling implements Serializable {
             return this;
         }
         if (function == null || function.equals("")) {
-            this.expressions.remove(attribute);
             this.functions.remove(attribute);
             return this;
         }
@@ -132,7 +147,6 @@ public class ARXFeatureScaling implements Serializable {
         if (expression.getVariableNames().size() != 1 || !expression.getVariableNames().contains("x")) {
             throw new IllegalArgumentException("Function must have exactly one variable 'x': " + function);
         }
-        this.expressions.put(attribute, expression);
         this.functions.put(attribute, function);
         return this;
     }


### PR DESCRIPTION
Remove net.objecthunter.exp4j.Expression from class member since this
class is not serializable.