### PR TITLE
Bugfix GUI: use non-predefined feature scaling function

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewStatisticsClassificationAttributes.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewStatisticsClassificationAttributes.java
@@ -443,6 +443,7 @@ public class ViewStatisticsClassificationAttributes implements IView, ViewStatis
                     @Override
                     public void keyReleased(KeyEvent arg0) {
                         updateCombo(attribute, combo, defaultColor);
+                        updateFunction(attribute, combo);
                     }
                 });
                 combo.addKeyListener(new DelayedChangeListener(DELAY) {


### PR DESCRIPTION
When typing custom feature scaling function, the function has to be updated in the model.