### PR TITLE
Bugfix: ArrayIndexOutOfBoundException.

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewStatisticsClassification.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/utility/ViewStatisticsClassification.java
@@ -243,9 +243,6 @@ public abstract class ViewStatisticsClassification extends ViewStatistics<Analys
                             getController().update(new ModelEvent(ViewStatisticsClassification.this,
                                                                   ModelPart.SELECTED_ATTRIBUTE,
                                                                   getModel().getSelectedAttribute()));
-                            getController().update(new ModelEvent(ViewStatisticsClassification.this,
-                                                                  ModelPart.SELECTED_CLASS_VALUE,
-                                                                  getModel().getSelectedClassValue()));
                             return;
                         }
                         if (!visible && rect.intersects(clientArea)) {


### PR DESCRIPTION
Initial situation:
- Perform classification on input and output with 2 target variables
- Select a third target variable (classification is started
automatically on click), but cancel classification of output
	
Bug:
- IndexArrayOutOfBoundsException when clicking an attribute in the input
performance table

Cause:
- The click triggers the event 'SELECTED_ATTRIBUTE' which will start
classification of the output in a separate thread. When finished, the
attributes of the ROC combo will be updated.
- The click triggers the event 'SELECTED_CLASS' which will trigger an
update of the ROC selection. The ROC to be updated is determined based
on the selected attribute.
- The Problem: When the classification thread is not completed before
the 'SELECTED_CLASS' event is thrown, the ROC combo might contain a
wrong number of attributes.

Solution:
- Do not throw the event 'SELECTED_CLASS' when clicking on an attribute.
This leads to the bug and is not necessary either.