### PR TITLE
Include *.r files in build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
                     <include>**/*.gif</include>
                     <include>**/*.pdf</include>
                     <include>**/*.txt</include>
+                    <include>**/*.r</include>
                 </includes>
             </resource>
             <resource>


### PR DESCRIPTION
This is a fix for the following bug:

java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at java.nio.file.Files.copy(Files.java:2984)
	at org.deidentifier.arx.gui.resources.Resources.getRScript(Resources.java:407)
	at org.deidentifier.arx.gui.view.impl.utility.ViewStatisticsROptions$1.widgetSelected(ViewStatisticsROptions.java:90)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(Unknown Source)

