### PR TITLE
Fixed nullpointer on help

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/Controller.java
+++ b/src/gui/org/deidentifier/arx/gui/Controller.java
@@ -1762,7 +1762,7 @@ public class Controller implements IView {
      * @param id
      */
     public void actionShowHelpDialog(String id) {
-        main.showHelpDialog(model.isHelpDialogModal(), id);
+        main.showHelpDialog(model == null || model.isHelpDialogModal(), id);
     }
 
     /**


### PR DESCRIPTION
Opening the help menu caused a nullpointer as the model object is only available after a project is created. Will now by default open the help menu with modal on false. Another possible solution could be to disable the help menu when a project does not exist.