### PR TITLE
Minor fix in HierarchyBuilderDate for Day of Week/Weekday

### DIFF
--- a/src/main/org/deidentifier/arx/aggregates/HierarchyBuilderDate.java
+++ b/src/main/org/deidentifier/arx/aggregates/HierarchyBuilderDate.java
@@ -189,7 +189,7 @@ public class HierarchyBuilderDate extends HierarchyBuilder<Date> implements Seri
         /**  Granularity */
         QUARTER_YEAR("QQQ yyyy"),
         /**  Granularity */
-        WEEKDAY("u"),
+        WEEKDAY("e"),
         /**  Granularity */
         WEEK("w"),
         /**  Granularity */


### PR DESCRIPTION
Changed format for WEEKDAY (or “Day of Week” in GUI) from „u“ (year) to „e” (localized day-of-week). Reference:  https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html