### PR TITLE
show tooltip for attributes in weight view

### DIFF
--- a/src/gui/org/deidentifier/arx/gui/view/impl/define/ViewAttributeWeights.java
+++ b/src/gui/org/deidentifier/arx/gui/view/impl/define/ViewAttributeWeights.java
@@ -366,6 +366,7 @@ public class ViewAttributeWeights implements IView {
             for (int i = 0; i < sortedAttributes.size(); i++) {
                 Label label = new Label(composites.get(i), SWT.CENTER);
                 label.setText(sortedAttributes.get(i));
+                label.setToolTipText(sortedAttributes.get(i));
                 label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
             }
             


### PR DESCRIPTION
This is useful when an attribute does not show up correctly on the label e.g. 
<img width="481" alt="arxWeightsIssue" src="https://user-images.githubusercontent.com/28802516/206996338-c92cddaf-407e-4573-b2b4-e8d065944f9d.PNG">
