### PR TITLE
Format fixes in HierarchyBuilderDate

### DIFF
--- a/src/main/org/deidentifier/arx/aggregates/HierarchyBuilderDate.java
+++ b/src/main/org/deidentifier/arx/aggregates/HierarchyBuilderDate.java
@@ -68,7 +68,7 @@ public class HierarchyBuilderDate extends HierarchyBuilder<Date> implements Seri
             map.put(Granularity.HOUR_DAY_MONTH_YEAR, "dd.MM.yyyy-HH:00");
             map.put(Granularity.DAY_MONTH_YEAR, "dd.MM.yyyy");
             map.put(Granularity.WEEK_MONTH_YEAR, "W/MM.yyyy");
-            map.put(Granularity.WEEK_YEAR, "ww/yyyy");
+            map.put(Granularity.WEEK_YEAR, "ww/YYYY");
             map.put(Granularity.MONTH_YEAR, "MM/yyyy");
             map.put(Granularity.QUARTER_YEAR, "QQQ yyyy");
         }
@@ -183,7 +183,7 @@ public class HierarchyBuilderDate extends HierarchyBuilder<Date> implements Seri
         /**  Granularity */
         WEEK_MONTH_YEAR("W/MM.yyyy"),
         /**  Granularity */
-        WEEK_YEAR("ww/yyyy"),
+        WEEK_YEAR("ww/YYYY"),
         /**  Granularity */
         MONTH_YEAR("MM/yyyy"),
         /**  Granularity */
@@ -542,10 +542,10 @@ public class HierarchyBuilderDate extends HierarchyBuilder<Date> implements Seri
         if (_range == null) {
             return formatter.format(dateTime);
         } else {
-            int dateUnit = Integer.valueOf(formatter.format(dateTime));
+            int dateUnit = Integer.valueOf(formatter.format(dateTime)) - 1;
             int lower    = Integer.valueOf((dateUnit) / (_range))  * (_range);
             int upper    = lower + _range;
-            String outputDate = "[" + lower + ", " + upper + "[";
+            String outputDate = "[" + (lower+1) + ", " + (upper+1) + "[";
             return outputDate;
         }
     }


### PR DESCRIPTION
This pull request fixes two bugs in the HierarchyBuilder for date properties.

The first bug has to do with the "WEEK_YEAR" granularity. This granularity uses the "week-of-week-based-year" format in the Java DateTimeFormatter. This formats the week to a number with a maximum of 52 However, a year can contain a partial 53th week when the year doesn't end in a sunday. This 53th week gets the number 1 of the next year as "week-of-week-based-year" value. This currently causes dates such as 01/01/2019 and 31/12/2019 both to be generalized to 01/2019 while being almost a year apart. The pull request fixes this by replacing the "yyyy" ("year-of-era") format with the "YYYY" ("week-based-year") causing 01/01/2019 and 31/12/2019 to be generalized to a different value. Namely 01/2019 and 01/2020.
https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html

The second bug has to do with the definitions of "DECADE", "CENTURY" and "MILLENNIUM". All these units currently generalize the year to ranges where the first included year ends with a 0. However decades, centuries and millenniums are defined to start with the year ending in 1 (example: 21th-century includes all years starting from 2001 up and to including 2100). The pull request fixes this by changing the generalize function increasing the bound by 1 and shifting when a certain range is used.
https://en.wikipedia.org/wiki/Century