### PR TITLE
Fix issue #460

### DIFF
--- a/src/main/org/deidentifier/arx/io/CSVDataInput.java
+++ b/src/main/org/deidentifier/arx/io/CSVDataInput.java
@@ -587,6 +587,7 @@ public class CSVDataInput {
         format.setComment('\0');
 
         CsvParserSettings settings = new CsvParserSettings();
+        settings.setSkipEmptyLines(false);
         settings.setEmptyValue("");
         settings.setNullValue("");
         settings.setFormat(format);

--- a/src/main/org/deidentifier/arx/io/CSVDataOutput.java
+++ b/src/main/org/deidentifier/arx/io/CSVDataOutput.java
@@ -409,6 +409,7 @@ public class CSVDataOutput {
         format.setNormalizedNewline(CSVSyntax.getNormalizedLinebreak(linebreak));
 
         CsvWriterSettings settings = new CsvWriterSettings();
+        settings.setSkipEmptyLines(false);
         settings.setEmptyValue("");
         settings.setNullValue("");
         settings.setFormat(format);


### PR DESCRIPTION
This patch tries to fix issue #460. This issue was caused by not writing empty lines to the hierarchy csv files in the project.
This resulted in the removal of possible empty string Quasi-identifiers in the hierarchy when only 1 level is specified.