### PR TITLE
Experimental mvn build

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -74,8 +74,3 @@ mvn install:install-file \
   -Dpackaging=jar
 
 echo "Dependencies installed successfully!"
-
-echo "Building with profile: $PROFILE"
-mvn clean package compile -P "$PROFILE" -Dcore=true -DskipTests
-
-echo "Build completed successfully!"

--- a/mvn_build.sh
+++ b/mvn_build.sh
@@ -14,6 +14,14 @@ mvn install:install-file \
   -DgroupId=org.eclipse \
   -DartifactId=draw2d \
   -Dversion=3.10.100 \
+  -Dpackaging=jar \
+  -DgeneratePom=true
+
+mvn install:install-file \
+  -Dfile=lib/ant/smile/smile-1.3.1-java7.jar \
+  -DgroupId=com.github.haifengl \
+  -DartifactId=smile \
+  -Dversion=1.3.1 \
   -Dpackaging=jar
 
 OS=$(uname -s)

--- a/mvn_build.sh
+++ b/mvn_build.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+echo "Installing Maven dependencies..."
+
+mvn install:install-file \
+  -Dfile=lib/ant/poi/poi-3.10-FINAL-20140208.jar \
+  -DgroupId=com.apache.poi \
+  -DartifactId=poi \
+  -Dversion=3.10-FINAL \
+  -Dpackaging=jar
+
+mvn install:install-file \
+  -Dfile=lib/ant/eclipse/org.eclipse.draw2d_3.10.100.201606061308.jar \
+  -DgroupId=org.eclipse \
+  -DartifactId=draw2d \
+  -Dversion=3.10.100 \
+  -Dpackaging=jar
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64|amd64)
+    MAVEN_ARCH="x86_64"
+    ;;
+  arm64|aarch64)
+    MAVEN_ARCH="aarch64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+case "$OS" in
+  Linux*)
+    SWT_FILE="lib/ant/eclipse/org.eclipse.swt.gtk.linux.x86_64_3.114.100.v20200604-0951.jar"
+    SWT_ARTIFACTID="org.eclipse.swt.gtk.linux.x86_64"
+    PROFILE="gtk-64"
+    PLATFORM="Linux"
+    ;;
+  Darwin*)
+    SWT_FILE="lib/ant/eclipse/org.eclipse.swt.cocoa.macosx.x86_64_3.114.100.v20200604-0951.jar"
+    SWT_ARTIFACTID="org.eclipse.swt.cocoa.macosx.x86_64"
+    PROFILE="osx-64"
+    PLATFORM="macOS"
+    ;;
+  CYGWIN*|MINGW*|MSYS*|Windows*)
+    SWT_FILE="lib/ant/eclipse/org.eclipse.swt.win32.win32.x86_64_3.114.100.v20200604-0951.jar"
+    SWT_ARTIFACTID="org.eclipse.swt.win32.win32.x86_64"
+    PROFILE="win-64"
+    PLATFORM="Windows"
+    ;;
+  *)
+    echo "Unsupported operating system: $OS"
+    exit 1
+    ;;
+esac
+
+echo "Detected platform: $PLATFORM ($ARCH)"
+echo "Installing SWT library: $SWT_ARTIFACTID"
+
+if [ ! -f "$SWT_FILE" ]; then
+    echo "Error: SWT library file not found: $SWT_FILE"
+    echo "Please ensure the correct SWT library for your platform is in the lib/ant/eclipse/ directory."
+    exit 1
+fi
+
+mvn install:install-file \
+  -Dfile="$SWT_FILE" \
+  -DgroupId=org.eclipse.platform \
+  -DartifactId="$SWT_ARTIFACTID" \
+  -Dversion=3.114.100 \
+  -Dpackaging=jar
+
+echo "Dependencies installed successfully!"
+
+echo "Building with profile: $PROFILE"
+mvn clean package compile -P "$PROFILE" -Dcore=true -DskipTests
+
+echo "Build completed successfully!"

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <dependency>
             <groupId>com.github.ralfstuckert.pdfbox-layout</groupId>
             <artifactId>pdfbox2-layout</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -328,7 +328,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.1</version>
+            <version>3.10-FINAL</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -390,11 +390,10 @@
             <artifactId>org.eclipse.core.runtime</artifactId>
             <version>3.18.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.eclipse/draw2d -->
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>draw2d</artifactId>
-            <version>3.2.100-v20070529</version>
+            <version>3.10.100</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.equinox.common -->
         <dependency>
@@ -720,7 +719,7 @@
                 </dependency>
             </dependencies>
         </profile>
-	<profile>
+	    <profile>
             <id>core</id>
             <activation>
                 <property>
@@ -757,6 +756,7 @@
                                 <configuration>
                                     <sources>
                                         <source>${project.basedir}/src/main</source>
+                                        <source>${project.basedir}/src/gui</source> 
                                         <source>${project.basedir}/src/example</source>
                                     </sources>
                                 </configuration>

--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,13 @@ Development setup
 
 Currently, the main development of ARX is carried out using Eclipse as an IDE and Ant as a build tool. Support for further IDEs such as IntelliJ IDEA and Maven is experimental.
 
-The Ant build script features various targets that can be used to build different versions of ARX (e.g. including GUI code or not). To build only the core code using Maven, set the system property `core` to `true`. This will build a platform independent jar with the ARX main code module and no GUI components:
+The Ant build script features various targets that can be used to build different versions of ARX (e.g. including GUI code or not).
 
-```$ mvn compile -Dcore=true``` 
+To build a platform independent jar using Maven, execute the maven build script that will compile both the ARX main code module and GUI components:
+
+```bash
+./mvn_build.sh
+``` 
 
 Contributing and code of conduct
 ------

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Currently, the main development of ARX is carried out using Eclipse as an IDE an
 
 The Ant build script features various targets that can be used to build different versions of ARX (e.g. including GUI code or not).
 
-To build the project, run the Maven install script once to register dependencies, then execute the build process via Maven CLI to compile both the ARX main code module and GUI components:
+To build the project with Maven, run install script once to register dependencies, then execute the build process via Maven CLI to compile both the ARX main code module and GUI components:
 
 ```bash
 ./install_deps.sh

--- a/readme.md
+++ b/readme.md
@@ -35,10 +35,13 @@ Currently, the main development of ARX is carried out using Eclipse as an IDE an
 
 The Ant build script features various targets that can be used to build different versions of ARX (e.g. including GUI code or not).
 
-To build a platform independent jar using Maven, execute the maven build script that will compile both the ARX main code module and GUI components:
+To build the project, run the Maven install script once to register dependencies, then execute the build process via Maven CLI to compile both the ARX main code module and GUI components:
 
 ```bash
-./mvn_build.sh
+./install_deps.sh
+
+# Profiles: gtk-64 (Linux), win-64 (Windows), osx-64 (Mac)
+mvn clean package compile -P gtk-64 -Dcore=true -DskipTests 
 ``` 
 
 Contributing and code of conduct

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Currently, the main development of ARX is carried out using Eclipse as an IDE an
 
 The Ant build script features various targets that can be used to build different versions of ARX (e.g. including GUI code or not).
 
-To build the project with Maven, run install script once to register dependencies, then execute the build process via Maven CLI to compile both the ARX main code module and GUI components:
+To build the project with Maven, run the install script once to register dependencies, then execute the build process via Maven CLI to compile both the ARX main code module and GUI components:
 
 ```bash
 ./install_deps.sh


### PR DESCRIPTION
Added an experimental build script for Windows/Linux/Mac that sources local jar files for some libraries (poi, draw2d, smile and swt) instead of pulling from maven central (some versions are not available there).

Tested under Windows (11 and Git Bash) and Linux (Ubuntu 24.02).